### PR TITLE
added getCDP using mocked redemptionRate

### DIFF
--- a/src/AlchemistV3.sol
+++ b/src/AlchemistV3.sol
@@ -122,9 +122,6 @@ contract AlchemistV3 is IAlchemistV3, Initializable, Multicall, Mutex {
 
         uint256 redemptionRequestForUser = getRedemptionAmountRequestForUser(yieldToken, owner);
 
-        /// @dev mocked number of total borrowers. Not sure if this matters
-        uint256 totalBorrowersForThisAlchemist = 1;
-
         depositedCollateral = totalValue(owner);
 
         debt = account.debt;
@@ -1396,8 +1393,8 @@ contract AlchemistV3 is IAlchemistV3, Initializable, Multicall, Mutex {
         /// @dev mocked arbitrary cap on what the Transmuter can pull from
         uint256 maxRedeemableCollateral = collateralForThisAlchemist / LTV;
 
-        /// @dev yield requested from Transmuter for this Alchemist is at .01% per second which is high
-        /// so articialliay increasing this denom to drecrease the amount requested
+        /// @dev amount requested from Transmuter for this Alchemist is at .01% per second which is high
+        /// so artificially increasing this denominator to decrease the amount requested
         return (redemptionRate * maxRedeemableCollateral) / (BPS * 100);
     }
 

--- a/src/AlchemistV3.sol
+++ b/src/AlchemistV3.sol
@@ -1376,7 +1376,7 @@ contract AlchemistV3 is IAlchemistV3, Initializable, Multicall, Mutex {
 
     /// @inheritdoc IAlchemistV3State
     function getYieldRequestForAlchemist(address yieldToken) public view returns (uint256) {
-        /// @dev mocked rate at 1 bps or .001 % per second
+        /// @dev mocked rate at 1 bps or .01 % per second
         uint256 redemptionRate = 1;
 
         uint256 collateralForThisAlchemist = IERC20(yieldToken).balanceOf(address(this));
@@ -1384,7 +1384,7 @@ contract AlchemistV3 is IAlchemistV3, Initializable, Multicall, Mutex {
         /// @dev mocked arbitrary cap on what the Transmuter can pull from
         uint256 maxRedeemableCollateral = collateralForThisAlchemist / 100;
 
-        /// @dev yield requested from Transmuter for this Alchemist is at .001% of the capped collateral
+        /// @dev yield requested from Transmuter for this Alchemist is at .01% of the capped collateral
         return (redemptionRate * maxRedeemableCollateral) / BPS;
     }
 

--- a/src/interfaces/alchemist/IAlchemistV3State.sol
+++ b/src/interfaces/alchemist/IAlchemistV3State.sol
@@ -222,6 +222,25 @@ interface IAlchemistV3State {
     /// @return maximum      The maximum possible amount of tokens that can be repaid at a time.
     function getRepayLimitInfo(address underlyingToken) external view returns (uint256 currentLimit, uint256 rate, uint256 maximum);
 
+    /// @notice Checks elapsed time since the account owned by `owner` has created a loan / debts been reset to zero
+    ///
+    /// @param owner The address of the account owner.
+    /// @return params elapsed time in seconds
+    function elapsedSecondsSinceLoan(address owner) external view returns (uint256);
+
+    /// @notice Gets amount needed by Transmuter for redemptions. Should make use of the getRedmptionRate() on the Transmuter.
+    ///
+    /// @param yieldToken The yield token address for the specified Alchemist
+    /// @return params yield amount neeeded
+    function getYieldRequestForAlchemist(address yieldToken) external view returns (uint256);
+
+    /// @notice Gets deposit and debt of the account owned by `owner`.
+    ///
+    /// @param owner The address of the account owner.
+    /// @return depositedCollateral total deposit from owner
+    /// @return debt current debt of owner
+    function getCDP(address owner) external view returns (uint256 depositedCollateral, int256 debt);
+
     /// @notice Gets current limit, maximum, and rate of the liquidation limiter for `underlyingToken`.
     ///
     /// @param underlyingToken The address of the underlying token.

--- a/src/interfaces/alchemist/IAlchemistV3State.sol
+++ b/src/interfaces/alchemist/IAlchemistV3State.sol
@@ -222,25 +222,6 @@ interface IAlchemistV3State {
     /// @return maximum      The maximum possible amount of tokens that can be repaid at a time.
     function getRepayLimitInfo(address underlyingToken) external view returns (uint256 currentLimit, uint256 rate, uint256 maximum);
 
-    /// @notice Checks elapsed time since the account owned by `owner` has created a loan / debts been reset to zero
-    ///
-    /// @param owner The address of the account owner.
-    /// @return params elapsed time in seconds
-    function elapsedSecondsSinceLoan(address owner) external view returns (uint256);
-
-    /// @notice Gets total amount needed by Transmuter for redemptions. Should make use of the getRedmptionRate() on the Transmuter.
-    ///
-    /// @param yieldToken The yield token address for the specified Alchemist
-    /// @return params yield amount neeeded
-    function getRedemptionRequestForAlchemist(address yieldToken) external view returns (uint256);
-
-    /// @notice Gets share of redemption amout for user.
-    ///
-    /// @param yieldToken The yield token address for the specified Alchemist
-    /// @param owner The address of the account owner.
-    /// @return params redemption amount neeeded
-    function getRedemptionAmountRequestForUser(address yieldToken, address owner) external view returns (uint256);
-
     /// @notice Gets deposit and debt of the account owned by `owner`.
     ///
     /// @param owner The address of the account owner.

--- a/src/interfaces/alchemist/IAlchemistV3State.sol
+++ b/src/interfaces/alchemist/IAlchemistV3State.sol
@@ -228,11 +228,18 @@ interface IAlchemistV3State {
     /// @return params elapsed time in seconds
     function elapsedSecondsSinceLoan(address owner) external view returns (uint256);
 
-    /// @notice Gets amount needed by Transmuter for redemptions. Should make use of the getRedmptionRate() on the Transmuter.
+    /// @notice Gets total amount needed by Transmuter for redemptions. Should make use of the getRedmptionRate() on the Transmuter.
     ///
     /// @param yieldToken The yield token address for the specified Alchemist
     /// @return params yield amount neeeded
-    function getYieldRequestForAlchemist(address yieldToken) external view returns (uint256);
+    function getRedemptionRequestForAlchemist(address yieldToken) external view returns (uint256);
+
+    /// @notice Gets share of redemption amout for user.
+    ///
+    /// @param yieldToken The yield token address for the specified Alchemist
+    /// @param owner The address of the account owner.
+    /// @return params redemption amount neeeded
+    function getRedemptionAmountRequestForUser(address yieldToken, address owner) external view returns (uint256);
 
     /// @notice Gets deposit and debt of the account owned by `owner`.
     ///

--- a/src/test/AlchemistV3.t.sol
+++ b/src/test/AlchemistV3.t.sol
@@ -17,6 +17,8 @@ import {TestYieldTokenAdapter} from "./mocks/TestYieldTokenAdapter.sol";
 import "../../../lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {CheatCodes} from "./utils/Cheatcodes.sol";
 import "../libraries/SafeCast.sol";
+import {console} from "../../lib/forge-std/src/console.sol";
+import "../libraries/SafeCast.sol";
 
 contract AlchemistV3Test is DSTestPlus {
     // ----- [SETUP] Variables for setting up a minimal CDP -----
@@ -60,6 +62,9 @@ contract AlchemistV3Test is DSTestPlus {
     address public alOwner;
 
     mapping(address => bool) users;
+
+    // LTV
+    uint256 public LTV = 11e17; // 1.1, prev = 2 * 1e18
 
     // ----- Variables for deposits & withdrawals -----
 
@@ -119,7 +124,7 @@ contract AlchemistV3Test is DSTestPlus {
             admin: alOwner,
             debtToken: address(alToken),
             transmuter: address(transmuterBuffer),
-            minimumCollateralization: 2 * 1e18,
+            minimumCollateralization: LTV,
             protocolFee: 1000,
             protocolFeeReceiver: address(10),
             mintingLimitMinimum: 1,
@@ -209,13 +214,17 @@ contract AlchemistV3Test is DSTestPlus {
         hevm.stopPrank();
     }
 
-    function testCDPWithPositiveDebt() external {
+    function testCDPPositionWithZeroAPY1Day() external {
         /// @dev minting a half of the collateral
-        uint256 mintAmount = depositAmount / 2;
+        uint256 mintAmount = 80_000e18;
 
         /// @dev expected debt after 1 day / 86400s for a speicifc user with 50,000 debt
         /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
-        uint256 debAfterOneDay = 4_999_995e16;
+        uint256 debAfterOneDay = 79_988_792_120_269_569_764_160;
+
+        /// @dev expected deposit after 1 day / 86400s for a specific user with 100,000 deposit
+        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
+        uint256 depositAfterOneDay = 99_988_792_120_269_569_764_160;
 
         hevm.prank(address(0xdead));
 
@@ -242,9 +251,85 @@ contract AlchemistV3Test is DSTestPlus {
 
         (deposit, debt) = alchemist.getCDP(address(0xbeef));
 
-        assertApproxEq(deposit, depositAmount, minimumDepositOrWithdrawalLoss);
+        assertApproxEq(deposit, depositAfterOneDay, minimumDepositOrWithdrawalLoss);
 
         assertApproxEq(SafeCast.toUint256(debt), debAfterOneDay, minimumDepositOrWithdrawalLoss);
+
+        hevm.stopPrank();
+    }
+
+    function testCDPPositionWithZeroAPY1Month() external {
+        /// @dev minting a half of the collateral
+        uint256 mintAmount = 80_000e18;
+
+        /// @dev expected debt after 1 month for a specific user with 80,000 debt
+        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
+        uint256 debAfterOneMonth = 79_246_832_792_141_005_852_324;
+
+        /// @dev expected deposit after 1 month for a specific user with 100,000 deposit
+        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
+        uint256 depositAfterOneMonth = 99_246_832_792_141_005_852_324;
+
+        /// @dev faking total collateral in aclhemist after 1 month @ 12% APY using fake yeild with
+        /// a previous collateral of 900,000
+        uint256 initialAlchemistCollateral = 909_000e18;
+
+        uint256 initialBorrowedAmount = 280_000e18;
+
+        deal(address(fakeYieldToken), address(0xD4D86f77aC52E0e8a26E474503C51930F022649f), accountFunds);
+
+        hevm.startPrank(address(0xdead));
+
+        vm.warp(1_719_590_015);
+
+        whitelist.add(address(0xbeef));
+
+        whitelist.add(address(0xD4D86f77aC52E0e8a26E474503C51930F022649f));
+
+        hevm.stopPrank();
+
+        /// simulating mint from a user
+
+        hevm.startPrank(address(0xD4D86f77aC52E0e8a26E474503C51930F022649f));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), initialAlchemistCollateral, address(0xD4D86f77aC52E0e8a26E474503C51930F022649f));
+
+        alchemist.mint(initialBorrowedAmount, address(0xD4D86f77aC52E0e8a26E474503C51930F022649f));
+
+        hevm.stopPrank();
+
+        /// simulating mint from another user with a smaller resulting debt share
+
+        hevm.startPrank(address(0xbeef));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
+
+        alchemist.mint(mintAmount, address(0xbeef));
+
+        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
+
+        /// cdp of user with small debt share on day 1
+
+        assertApproxEq(deposit, depositAmount, minimumDepositOrWithdrawalLoss);
+
+        assertApproxEq(SafeCast.toUint256(debt), mintAmount, minimumDepositOrWithdrawalLoss);
+
+        /// cdp of the same user with small debt share after 1 month
+
+        // warp by 1 month. i.e. 86400s per day for Roughly 30 days
+        vm.warp(1_719_590_095 + (30 * 86_400));
+
+        (deposit, debt) = alchemist.getCDP(address(0xbeef));
+
+        // i.e. 100,000 collateral - ((.001307 alAsset per second * 86400 seconds * 30 days ) * 0.22 share of debt)
+        assertApproxEq(deposit, depositAfterOneMonth, minimumDepositOrWithdrawalLoss);
+
+        // i.e. 80,000 debt - ((.001307 alAsset per second * 86400 seconds * 30 days ) * 0.22 share of debt)
+        assertApproxEq(SafeCast.toUint256(debt), debAfterOneMonth, minimumDepositOrWithdrawalLoss);
 
         hevm.stopPrank();
     }

--- a/src/test/AlchemistV3.t.sol
+++ b/src/test/AlchemistV3.t.sol
@@ -215,7 +215,7 @@ contract AlchemistV3Test is DSTestPlus {
 
         /// @dev expected debt after 1 day / 86400s for a speicifc user with 50,000 debt
         /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
-        uint256 debAfterOneDay = 41_352e18;
+        uint256 debAfterOneDay = 4_999_995e16;
 
         hevm.prank(address(0xdead));
 


### PR DESCRIPTION
Summary 

- Added experimental implementation of the [getCDP](https://github.com/alchemix-finance/v3-poc/blob/3928fdada010807c57192ae1f6fca0cb944e291c/src/AlchemistV3.sol#L114) function. See [Spec](url).
- Mocking a fixed redemption rate at 1% of collateral per month (3858e7% per second -> 3858e9 yieldToken per second) of an arbitrary amount of collateral for a single alchemist.
- Reducing a users debt & (collateral + yield) via the redemption amount by looking at a fixed redemption amount over a time t in seconds.

Things that need discussion

- Redemption rates 
- How a single users collateral & debt is actually affected by redemption
- Guard rails for what amount of collateral is to be used for redemptions

Tests

- Test for a users debt change for fixed redemption amounts over a time t in seconds.

TODO

- Review any more docs or spreadsheet simulations to help with algorithm adjustments