### PR TITLE
added basic test cases for varying ltvs and time

### DIFF
--- a/src/test/AlchemistV3.t.sol
+++ b/src/test/AlchemistV3.t.sol
@@ -88,10 +88,6 @@ contract AlchemistV3Test is Test {
     // another random EOA for testing
     address anotherExternalUser = address(0x420Ab24368E5bA8b727E9B8aB967073Ff9316969);
 
-    // Real Tokens
-    IERC20 constant dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
-    IERC20 constant yvDai = IERC20(0xdA816459F1AB5631232FE5e97a05BBBb94970c95);
-
     function setUp() external {
         // test maniplulation for convenience
         address caller = address(0xdead);

--- a/src/test/AlchemistV3.t.sol
+++ b/src/test/AlchemistV3.t.sol
@@ -20,6 +20,8 @@ import {console} from "../../lib/forge-std/src/console.sol";
 import "../libraries/SafeCast.sol";
 import "../../lib/forge-std/src/Test.sol";
 
+import {ITestYieldToken} from "../interfaces/test/ITestYieldToken.sol";
+
 contract AlchemistV3Test is Test {
     // ----- [SETUP] Variables for setting up a minimal CDP -----
 
@@ -69,7 +71,7 @@ contract AlchemistV3Test is Test {
     // ----- Variables for deposits & withdrawals -----
 
     // account funds to make deposits/test with
-    uint256 accountFunds = 10_000_000e18;
+    uint256 accountFunds = 20_000_000e18;
 
     // amount of yield/underlying token to deposit
     uint256 depositAmount = 100_000e18;
@@ -83,6 +85,13 @@ contract AlchemistV3Test is Test {
     // random EOA for testing
     address externalUser = address(0x69E8cE9bFc01AA33cD2d02Ed91c72224481Fa420);
 
+    // another random EOA for testing
+    address anotherExternalUser = address(0x420Ab24368E5bA8b727E9B8aB967073Ff9316969);
+
+    // Real Tokens
+    IERC20 constant dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    IERC20 constant yvDai = IERC20(0xdA816459F1AB5631232FE5e97a05BBBb94970c95);
+
     function setUp() external {
         // test maniplulation for convenience
         address caller = address(0xdead);
@@ -93,6 +102,7 @@ contract AlchemistV3Test is Test {
         vm.startPrank(caller);
 
         // Fake tokens
+
         TestERC20 testToken = new TestERC20(0, 18);
         fakeUnderlyingToken = address(testToken);
         TestYieldToken testYieldToken = new TestYieldToken(fakeUnderlyingToken);
@@ -177,15 +187,28 @@ contract AlchemistV3Test is Test {
         // // Set flow rate for transmuter buffer
         // transmuterBuffer.setFlowRate(fakeUnderlyingToken, 325e18);
 
+        whitelist.add(address(0xbeef));
+        whitelist.add(externalUser);
+        whitelist.add(anotherExternalUser);
+
         vm.stopPrank();
 
-        // Add funds to test account
+        // Add funds to test accounts
         deal(address(fakeYieldToken), address(0xbeef), accountFunds);
+        deal(address(fakeYieldToken), externalUser, accountFunds);
+        deal(address(fakeUnderlyingToken), anotherExternalUser, accountFunds);
+
+        vm.startPrank(anotherExternalUser);
+
+        SafeERC20.safeApprove(address(fakeUnderlyingToken), address(fakeYieldToken), accountFunds);
+
+        // faking initial token vault supply
+        ITestYieldToken(address(fakeYieldToken)).mint(15_000_000e18, anotherExternalUser);
+
+        vm.stopPrank();
     }
 
     function testDeposit() external {
-        vm.prank(address(0xdead));
-        whitelist.add(address(0xbeef));
         vm.startPrank(address(0xbeef));
         SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
         alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
@@ -194,8 +217,6 @@ contract AlchemistV3Test is Test {
     }
 
     function testWithdrawal() external {
-        vm.prank(address(0xdead));
-        whitelist.add(address(0xbeef));
         vm.startPrank(address(0xbeef));
         SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
         alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
@@ -206,8 +227,6 @@ contract AlchemistV3Test is Test {
     }
 
     function testCDPWithZeroDebt() external {
-        vm.prank(address(0xdead));
-        whitelist.add(address(0xbeef));
         vm.startPrank(address(0xbeef));
         SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
         alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
@@ -217,155 +236,43 @@ contract AlchemistV3Test is Test {
         vm.stopPrank();
     }
 
-    function testCDPPositionWithZeroAPY1Day() external {
-        uint256 mintAmount = 80_000e18;
+    /// High LTV Cases ------------------------------------------------------------------------------- ///
 
-        /// @dev expected debt after 1 day / 86400s for a speicifc user with 80,000 debt
-        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
-        uint256 debAfterOneDay = 79_988_792_120_269_569_764_160;
+    /// APY : 0% | Share of Debt : 22.22% | LTV : 80%  | Duration : 1 day  ///
 
-        /// @dev expected deposit after 1 day / 86400s for a specific user with 100,000 deposit
-        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
-        uint256 depositAfterOneDay = 99_988_792_120_269_569_764_160;
+    function testCDP0PercentAPY1DayHighShare1() external {
+        /// @dev mint amount used in this for the cdp postion test
+        uint256 mintAmountSmall = 80_000e18;
 
-        vm.prank(address(0xdead));
+        /// @dev starting debt position of this alchemist before user test
+        uint256 mintAmountLarge = 280_000e18;
 
-        vm.warp(1_719_590_015);
+        /// @dev expected debt after 1 day for a specific user with 80,000 debt
+        /// at a mocked redemption rate
+        uint256 debAfter1Day = 79_925_865_227_552_000_000_000;
 
-        whitelist.add(address(0xbeef));
-
-        vm.startPrank(address(0xbeef));
-
-        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
-
-        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
-
-        alchemist.mint(mintAmount, address(0xbeef));
-
-        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
-
-        vm.assertApproxEqAbs(deposit, depositAmount, minimumDepositOrWithdrawalLoss);
-
-        vm.assertApproxEqAbs(SafeCast.toUint256(debt), mintAmount, minimumDepositOrWithdrawalLoss);
-
-        // warp by 1 day / 86400s
-        vm.warp(1_719_590_095 + 86_400);
-
-        (deposit, debt) = alchemist.getCDP(address(0xbeef));
-
-        vm.assertApproxEqAbs(deposit, depositAfterOneDay, minimumDepositOrWithdrawalLoss);
-
-        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfterOneDay, minimumDepositOrWithdrawalLoss);
-
-        vm.stopPrank();
-    }
-
-    function testCDPPositionWithZeroAPY1Month() external {
-        uint256 mintAmount = 80_000e18;
-
-        /// @dev expected debt after 1 month for a specific user with 80,000 debt
-        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
-        uint256 debAfterOneMonth = 79_246_832_792_141_005_852_324;
-
-        /// @dev expected deposit after 1 month for a specific user with 100,000 deposit
-        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
-        uint256 depositAfterOneMonth = 99_246_832_792_141_005_852_324;
-
-        /// @dev faking total collateral in aclhemist
-        uint256 initialAlchemistCollateral = 909_000e18;
-
-        uint256 initialBorrowedAmount = 280_000e18;
-
-        deal(address(fakeYieldToken), address(0xD4D86f77aC52E0e8a26E474503C51930F022649f), accountFunds);
-
-        vm.startPrank(address(0xdead));
-
-        vm.warp(1_719_590_015);
-
-        whitelist.add(address(0xbeef));
-
-        whitelist.add(address(0xD4D86f77aC52E0e8a26E474503C51930F022649f));
-
-        vm.stopPrank();
-
-        /// simulating mint from a user
-
-        vm.startPrank(address(0xD4D86f77aC52E0e8a26E474503C51930F022649f));
-
-        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
-
-        alchemist.deposit(address(fakeYieldToken), initialAlchemistCollateral, address(0xD4D86f77aC52E0e8a26E474503C51930F022649f));
-
-        alchemist.mint(initialBorrowedAmount, address(0xD4D86f77aC52E0e8a26E474503C51930F022649f));
-
-        vm.stopPrank();
-
-        /// simulating mint from another user with a smaller resulting debt share
-
-        vm.startPrank(address(0xbeef));
-
-        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
-
-        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
-
-        alchemist.mint(mintAmount, address(0xbeef));
-
-        /// cdp of the same user with small debt share after 1 month
-
-        // warp by 1 month. i.e. 86400s per day for Roughly 30 days
-        vm.warp(1_719_590_095 + (30 * 86_400));
-
-        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
-
-        // i.e. 100,000 collateral - ((.001307 alAsset per second * 86400 seconds * 30 days ) * 0.22 share of debt)
-        vm.assertApproxEqAbs(deposit, depositAfterOneMonth, minimumDepositOrWithdrawalLoss);
-
-        // i.e. 80,000 debt - ((.001307 alAsset per second * 86400 seconds * 30 days ) * 0.22 share of debt)
-        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfterOneMonth, minimumDepositOrWithdrawalLoss);
-
-        vm.stopPrank();
-    }
-
-    function testCDPPositionWith12PercentAPY1Month() external {
-        uint256 mintAmount = 80_000e18;
-
-        /// @dev expected debt after 1 month for a specific user with 80,000 debt
-        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
-        uint256 debAfterOneMonth = 79_924_608_634_297_563_812_243;
-
-        /// @dev expected deposit after 1 month for a specific user with 100,000 deposit
-        /// at a mocked redemption rate on a capped amount of total collateral in an Alchemist
-        uint256 depositAfterOneMonth = 99_924_608_634_297_563_812_243;
+        /// @dev expected deposit after 1 day for a specific user with 100,000 deposit
+        /// at a mocked redemption rate
+        uint256 depositAfter1Day = 99_925_865_227_552_000_000_000;
 
         /// @dev faking total collateral
-        uint256 initialAlchemistCollateral = 900_000e18;
+        uint256 depositAmountLarge = 800_000e18;
 
-        /// @dev collateral after 1 month at 12% APY i.e. 1% increase per month starting from initial 900_000e18 + 100_000e18 deposited
-        uint256 alchemistCollateralAfter1Month = 101_000e18;
+        /// @dev faking underlying token supply of vault after 1 day at 12% APY i.e. 1% increase per month starting from the initial 15_000_000
+        uint256 vaultTotalSupplyAfter1Day = 15_000_000e18;
 
-        uint256 initialBorrowedAmount = 280_000e18;
-
-        deal(address(fakeYieldToken), externalUser, accountFunds);
-
+        // warp to a start time
         vm.warp(1_719_590_015);
 
-        vm.startPrank(address(0xdead));
-
-        whitelist.add(address(0xbeef));
-
-        whitelist.add(externalUser);
-
-        vm.stopPrank();
-
-        /// simulating mint from a user
+        /// simulating a desposit and mint from a user
 
         vm.startPrank(externalUser);
 
         SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
 
-        alchemist.deposit(address(fakeYieldToken), initialAlchemistCollateral, externalUser);
+        alchemist.deposit(address(fakeYieldToken), depositAmountLarge, externalUser);
 
-        alchemist.mint(initialBorrowedAmount, externalUser);
+        alchemist.mint(mintAmountLarge, externalUser);
 
         vm.stopPrank();
 
@@ -377,23 +284,486 @@ contract AlchemistV3Test is Test {
 
         alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
 
-        alchemist.mint(mintAmount, address(0xbeef));
+        alchemist.mint(mintAmountSmall, address(0xbeef));
+
+        // Fake yield accrual after 1 day @ 0% APY
+        deal(address(fakeUnderlyingToken), address(fakeYieldToken), vaultTotalSupplyAfter1Day, true);
+
+        // warp by 1 day. i.e. 86400s
+        vm.warp(1_719_590_095 + 86_400);
 
         /// cdp of the same user with small debt share after 1 month
-
-        // warp by 1 month. i.e. 86400s per day for Roughly 30 days
-        vm.warp(1_719_590_095 + (30 * 86_400));
-
-        // Fake yeild accrual after 1 month @ 12% APY
-        deal(address(fakeYieldToken), address(alchemist), alchemistCollateralAfter1Month);
-
         (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
 
-        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86400 seconds * 30 days ) * 0.22 share of debt)
-        vm.assertApproxEqAbs(deposit, depositAfterOneMonth, minimumDepositOrWithdrawalLoss);
+        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86_400 seconds * 1 day ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(deposit, depositAfter1Day, minimumDepositOrWithdrawalLoss);
 
-        // i.e. 80,000 debt - ((.001307 alAsset per second * 86400 seconds * 30 days ) * 0.22 share of debt)
-        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfterOneMonth, minimumDepositOrWithdrawalLoss);
+        // i.e. 80,000 debt - ((.001307 alAsset per second * 86_400 seconds * 1 day ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfter1Day, minimumDepositOrWithdrawalLoss);
+
+        vm.stopPrank();
+    }
+
+    /// APY : 0% | Share of Debt : 22.22% | LTV : 80%  | Duration : 1 month ///
+
+    function testCDP0PercentAPY1MonthHighShare1() external {
+        /// @dev mint amount used in this for the cdp postion test
+        uint256 mintAmountSmall = 80_000e18;
+
+        /// @dev starting debt position of this alchemist before user test
+        uint256 mintAmountLarge = 280_000e18;
+
+        /// @dev expected debt after 1 month for a specific user with 80,000 debt
+        /// at a mocked redemption rate
+        uint256 debAfter1Month = 77_777_945_640_992_000_000_000;
+
+        /// @dev expected deposit after 1 month for a specific user with 100,000 deposit
+        /// at a mocked redemption rate
+        uint256 depositAfter1Month = 97_777_945_640_992_000_000_000;
+
+        /// @dev faking total collateral
+        uint256 depositAmountLarge = 800_000e18;
+
+        /// @dev faking underlying token supply of vault after 1 month at 0% APY i.e. 1% increase per month starting from the initial 15_000_000
+        uint256 vaultTotalSupplyAfter1Month = 15_000_000e18;
+
+        // warp to a start time
+        vm.warp(1_719_590_015);
+
+        /// simulating a desposit and mint from a user
+
+        vm.startPrank(externalUser);
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmountLarge, externalUser);
+
+        alchemist.mint(mintAmountLarge, externalUser);
+
+        vm.stopPrank();
+
+        /// simulating mint from another user with a smaller resulting debt share
+
+        vm.startPrank(address(0xbeef));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
+
+        alchemist.mint(mintAmountSmall, address(0xbeef));
+
+        // Fake yield accrual after 1 month @ 0% APY
+        deal(address(fakeUnderlyingToken), address(fakeYieldToken), vaultTotalSupplyAfter1Month, true);
+
+        // warp by 1 month. i.e. 86400s per day for 1 month / Roughly 30 days
+        vm.warp(1_719_590_095 + (30 * 86_400));
+
+        /// cdp of the same user with small debt share after 1 month
+        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
+
+        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86_400 seconds * 30 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(deposit, depositAfter1Month, minimumDepositOrWithdrawalLoss);
+
+        // i.e. 80,000 debt - ((.001307 alAsset per second * 86_400 seconds * 30 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfter1Month, minimumDepositOrWithdrawalLoss);
+
+        vm.stopPrank();
+    }
+
+    /// APY : 12% | Share of Debt : 22.22% | LTV : 80%  | Duration : 1 month ///
+
+    function testCDP12PercentAPY1MonthHighShare1() external {
+        /// @dev mint amount used in this for the cdp postion test
+        uint256 mintAmountSmall = 80_000e18;
+
+        /// @dev starting debt position of this alchemist before user test
+        uint256 mintAmountLarge = 280_000e18;
+
+        /// @dev expected debt after 1 month for a specific user with 80,000 debt
+        /// at a mocked redemption rate
+        uint256 debAfter1Month = 77_777_945_640_992_000_000_000;
+
+        /// @dev expected deposit after 1 month for a specific user with 100,000 deposit
+        /// at a mocked redemption rate
+        uint256 depositAfter1Month = 98_777_945_640_991_999_999_997;
+
+        /// @dev faking total collateral
+        uint256 depositAmountLarge = 800_000e18;
+
+        /// @dev faking underlying token supply of vault after 1 month at 12% APY i.e. 1% increase per month starting from the initial 15_000_000
+        uint256 vaultTotalSupplyAfter1Month = 15_150_000e18;
+
+        // warp to a start time
+        vm.warp(1_719_590_015);
+
+        /// simulating a desposit and mint from a user
+
+        vm.startPrank(externalUser);
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmountLarge, externalUser);
+
+        alchemist.mint(mintAmountLarge, externalUser);
+
+        vm.stopPrank();
+
+        /// simulating mint from another user with a smaller resulting debt share
+
+        vm.startPrank(address(0xbeef));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
+
+        alchemist.mint(mintAmountSmall, address(0xbeef));
+
+        // Fake yield accrual after 1 month @ 12% APY
+        deal(address(fakeUnderlyingToken), address(fakeYieldToken), vaultTotalSupplyAfter1Month, true);
+
+        // warp by 1 month. i.e. 86400s per day for 1 month / Roughly 30 days
+        vm.warp(1_719_590_095 + (30 * 86_400));
+
+        /// cdp of the same user with small debt share after 1 month
+        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
+
+        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86_400 seconds * 30 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(deposit, depositAfter1Month, minimumDepositOrWithdrawalLoss);
+
+        // i.e. 80,000 debt - ((.001307 alAsset per second * 86_400 seconds * 30 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfter1Month, minimumDepositOrWithdrawalLoss);
+
+        vm.stopPrank();
+    }
+
+    // /// APY : 12% | Share of Debt : 22.22% | LTV : 80%  | Duration : 6 months ///
+
+    function testCDP12PercentAPY6MonthsHighShare1() external {
+        /// @dev mint amount used in this for the cdp postion test
+        uint256 mintAmountSmall = 80_000e18;
+
+        /// @dev starting debt position of this alchemist before user test
+        uint256 mintAmountLarge = 280_000e18;
+
+        /// @dev expected debt after 6 months for a specific user with 80,000 debt
+        /// at a mocked redemption rate
+        uint256 debAfter6Months = 66_668_016_744_992_000_000_000;
+
+        /// @dev expected deposit after 6 months for a specific user with 100,000 deposit
+        /// at a mocked redemption rate
+        uint256 depositAfter6Months = 92_820_030_078_325_333_299_997;
+
+        /// @dev faking total collateral
+        uint256 depositAmountLarge = 800_000e18;
+
+        /// @dev faking underlying token supply of vault after 6 months at 12% APY i.e. 1% increase per month starting from the initial 15_000_000
+        uint256 vaultTotalSupplyAfter6Months = 15_922_802e18;
+
+        // warp to a start time
+        vm.warp(1_719_590_015);
+
+        /// simulating a desposit and mint from a user
+
+        vm.startPrank(externalUser);
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmountLarge, externalUser);
+
+        alchemist.mint(mintAmountLarge, externalUser);
+
+        vm.stopPrank();
+
+        /// simulating mint from another user with a smaller resulting debt share
+
+        vm.startPrank(address(0xbeef));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
+
+        alchemist.mint(mintAmountSmall, address(0xbeef));
+
+        // Fake yield accrual after 6 months @ 12% APY
+        deal(address(fakeUnderlyingToken), address(fakeYieldToken), vaultTotalSupplyAfter6Months, true);
+
+        // warp by 6 months. i.e. 86400s per day for 1 month / Roughly 180 days
+        vm.warp(1_719_590_095 + (180 * 86_400));
+
+        /// cdp of the same user with small debt share after 6 months
+        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
+
+        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86_400 seconds * 180 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(deposit, depositAfter6Months, minimumDepositOrWithdrawalLoss);
+
+        // i.e. 80,000 debt - ((.001307 alAsset per second * 86_400 seconds * 180 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfter6Months, minimumDepositOrWithdrawalLoss);
+
+        vm.stopPrank();
+    }
+
+    /// APY : 12% | Share of Debt : 22.22% | LTV : 80%  | Duration : 12 months ///
+
+    function testCDP12PercentAPY12MonthsHighShare1() external {
+        /// @dev mint amount used in this for the cdp postion test
+        uint256 mintAmountSmall = 80_000e18;
+
+        /// @dev starting debt position of this alchemist before user test
+        uint256 mintAmountLarge = 280_000e18;
+
+        /// @dev expected debt after 12 months for a specific user with 80,000 debt
+        /// at a mocked redemption rate
+        uint256 debAfter12Months = 52_965_771_106_592_000_000_000;
+
+        /// @dev expected deposit after 12 months for a specific user with 100,000 deposit
+        /// at a mocked redemption rate
+        uint256 depositAfter12Months = 79_117_784_439_925_333_299_997;
+
+        /// @dev faking total collateral
+        uint256 depositAmountLarge = 800_000e18;
+
+        /// @dev faking underlying token supply of vault after 12 months at 12% APY i.e. 1% increase per month starting from the initial 15_000_000
+        uint256 vaultTotalSupplyAfter6Months = 15_922_802e18;
+
+        // warp to a start time
+        vm.warp(1_719_590_015);
+
+        /// simulating a desposit and mint from a user
+
+        vm.startPrank(externalUser);
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmountLarge, externalUser);
+
+        alchemist.mint(mintAmountLarge, externalUser);
+
+        vm.stopPrank();
+
+        /// simulating mint from another user with a smaller resulting debt share
+
+        vm.startPrank(address(0xbeef));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
+
+        alchemist.mint(mintAmountSmall, address(0xbeef));
+
+        // Fake yield accrual after 12 months @ 12% APY
+        deal(address(fakeUnderlyingToken), address(fakeYieldToken), vaultTotalSupplyAfter6Months, true);
+
+        // warp by 12 months. i.e. 86400s per day for 12 month / Roughly 365 days
+        vm.warp(1_719_590_095 + (365 * 86_400));
+
+        /// cdp of the same user with small debt share after 12 months
+        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
+
+        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86_400 seconds * 365 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(deposit, depositAfter12Months, minimumDepositOrWithdrawalLoss);
+
+        // i.e. 80,000 debt - ((.001307 alAsset per second * 86_400 seconds * 365 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfter12Months, minimumDepositOrWithdrawalLoss);
+
+        vm.stopPrank();
+    }
+
+    /// Low LTV Cases ------------------------------------------------------------------------------- ///
+
+    // APY : 12% | Share of Debt : 2.78% | LTV : 10%  | Duration : 1 month ///
+
+    function testCDP12PercentAPY1MonthLowShare1() external {
+        /// @dev mint amount used in this for the cdp postion test
+        uint256 mintAmountSmall = 10_000e18;
+
+        /// @dev starting debt position of this alchemist before user test
+        uint256 mintAmountLarge = 350_000e18;
+
+        /// @dev expected debt after 1 month month for a specific user with 10,000 debt
+        /// at a mocked redemption rate
+        uint256 debAfter1Month = 9_722_993_223_472_000_000_000;
+
+        /// @dev expected deposit after 1 month for a specific user with 100,000 deposit
+        /// at a mocked redemption rate
+        uint256 depositAfter1Month = 100_722_993_223_471_999_999_997;
+
+        /// @dev faking total collateral
+        uint256 depositAmountLarge = 800_000e18;
+
+        /// @dev faking underlying token supply of vault after 1 month at 12% APY i.e. 1% increase per month starting from the initial 15_000_000
+        uint256 vaultTotalSupplyAfter6Months = 15_150_000e18;
+
+        // warp to a start time
+        vm.warp(1_719_590_015);
+
+        /// simulating a desposit and mint from a user
+
+        vm.startPrank(externalUser);
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmountLarge, externalUser);
+
+        alchemist.mint(mintAmountLarge, externalUser);
+
+        vm.stopPrank();
+
+        /// simulating a desposit and mint from another user with a smaller resulting debt share
+
+        vm.startPrank(address(0xbeef));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
+
+        alchemist.mint(mintAmountSmall, address(0xbeef));
+
+        // Fake yield accrual after 1 month @ 12% APY
+        deal(address(fakeUnderlyingToken), address(fakeYieldToken), vaultTotalSupplyAfter6Months, true);
+
+        // warp by 1 month. i.e. 86400s per day for 6 months / Roughly 180 days
+        vm.warp(1_719_590_095 + (30 * 86_400));
+
+        /// cdp of the same user with small debt share after 1 month
+        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
+
+        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86_400 seconds * 30 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(deposit, depositAfter1Month, minimumDepositOrWithdrawalLoss);
+
+        // i.e. 10,000 debt - ((.001307 alAsset per second * 86_400 seconds * 30 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfter1Month, minimumDepositOrWithdrawalLoss);
+
+        vm.stopPrank();
+    }
+
+    // APY : 12% | Share of Debt : 2.78% | LTV : 10%  | Duration : 6 months ///
+
+    function testCDP12PercentAPY6MonthsLowShare1() external {
+        /// @dev mint amount used in this for the cdp postion test
+        uint256 mintAmountSmall = 10_000e18;
+
+        /// @dev starting debt position of this alchemist before user test
+        uint256 mintAmountLarge = 350_000e18;
+
+        /// @dev expected debt after 6 monghs month for a specific user with 10,000 debt
+        /// at a mocked redemption rate
+        uint256 debAfter6Months = 8_338_002_087_472_000_000_000;
+
+        /// @dev expected deposit after 6 months for a specific user with 100,000 deposit
+        /// at a mocked redemption rate
+        uint256 depositAfter6Months = 104_490_015_420_805_333_299_997;
+
+        /// @dev faking total collateral
+        uint256 depositAmountLarge = 800_000e18;
+
+        /// @dev faking underlying token supply of vault after 6 months at 12% APY i.e. 1% increase per month starting from the initial 15_000_000
+        uint256 vaultTotalSupplyAfter6Months = 15_922_802e18;
+
+        // warp to a start time
+        vm.warp(1_719_590_015);
+
+        /// simulating a desposit and mint from a user
+
+        vm.startPrank(externalUser);
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmountLarge, externalUser);
+
+        alchemist.mint(mintAmountLarge, externalUser);
+
+        vm.stopPrank();
+
+        /// simulating a desposit and mint from another user with a smaller resulting debt share
+
+        vm.startPrank(address(0xbeef));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
+
+        alchemist.mint(mintAmountSmall, address(0xbeef));
+
+        // Fake yield accrual after 6 months @ 12% APY
+        deal(address(fakeUnderlyingToken), address(fakeYieldToken), vaultTotalSupplyAfter6Months, true);
+
+        // warp by 6 months. i.e. 86400s per day for 6 months / Roughly 180 days
+        vm.warp(1_719_590_095 + (180 * 86_400));
+
+        /// cdp of the same user with small debt share after 6 months
+        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
+
+        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86_400 seconds * 180 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(deposit, depositAfter6Months, minimumDepositOrWithdrawalLoss);
+
+        // i.e. 10,000 debt - ((.001307 alAsset per seconds * 86_400 seconds * 180 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfter6Months, minimumDepositOrWithdrawalLoss);
+
+        vm.stopPrank();
+    }
+
+    /// APY : 12% | Share of Debt : 2.78% | LTV : 10%  | Duration : 12 months ///
+
+    function testCDP12PercentAPY12MonthsLowShare1() external {
+        /// @dev mint amount used in this for the cdp postion test
+        uint256 mintAmountSmall = 10_000e18;
+
+        /// @dev starting debt position of this alchemist before user test
+        uint256 mintAmountLarge = 350_000e18;
+
+        /// @dev expected debt after 12 monghs month for a specific user with 10,000 debt
+        /// at a mocked redemption rate
+        uint256 debAfter6Months = 6_629_846_353_072_000_000_000;
+
+        /// @dev expected deposit after 12 months for a specific user with 100,000 deposit
+        /// at a mocked redemption rate
+        uint256 depositAfter6Months = 109_312_346_353_071_999_999_997;
+
+        /// @dev faking total collateral
+        uint256 depositAmountLarge = 800_000e18;
+
+        /// @dev faking underlying token supply of vault after 12 months at 12% APY i.e. 1% increase per month starting from the initial 15_000_000
+        uint256 vaultTotalSupplyAfter6Months = 16_902_375e18;
+
+        // warp to a start time
+        vm.warp(1_719_590_015);
+
+        /// simulating a desposit and mint from a user
+
+        vm.startPrank(externalUser);
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmountLarge, externalUser);
+
+        alchemist.mint(mintAmountLarge, externalUser);
+
+        vm.stopPrank();
+
+        /// simulating mint from another user with a smaller resulting debt share
+
+        vm.startPrank(address(0xbeef));
+
+        SafeERC20.safeApprove(address(fakeYieldToken), address(alchemist), accountFunds);
+
+        alchemist.deposit(address(fakeYieldToken), depositAmount, address(0xbeef));
+
+        alchemist.mint(mintAmountSmall, address(0xbeef));
+
+        // Fake yield accrual after 12 months @ 12% APY
+        deal(address(fakeUnderlyingToken), address(fakeYieldToken), vaultTotalSupplyAfter6Months, true);
+
+        // warp by 12 months. i.e. 86400s per day for 12 months / Roughly 365 days
+        vm.warp(1_719_590_095 + (365 * 86_400));
+
+        /// cdp of the same user with small debt share after 6 months
+        (uint256 deposit, int256 debt) = alchemist.getCDP(address(0xbeef));
+
+        // i.e. 100,000 collateral + yield - ((.001307 alAsset per second * 86_400 seconds * 365 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(deposit, depositAfter6Months, minimumDepositOrWithdrawalLoss);
+
+        // i.e. 10,000 debt - ((.001307 alAsset per second * 86_400 seconds * 365 days ) * 0.0278 share of debt)
+        vm.assertApproxEqAbs(SafeCast.toUint256(debt), debAfter6Months, minimumDepositOrWithdrawalLoss);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
Added more test cases for varying user CDP levels.

Test cases correspond to Scoopy's sim [here](https://docs.google.com/spreadsheets/d/15Oz4RWN_bszJESS7Kg1Pzx5d2SmzEOh6QYHiAXAxzZc/edit?gid=0#gid=0)
for user 1 & user 8 for times : T1, T6 & T12. i.e. after 1 month, after 6 months and after 12 months.

Also doing cases with user 1 with 0% APY.


