### PR TITLE
7 - Missing _baseURI() override causes empty NFT metadata

### DIFF
--- a/src/AlchemistV3Position.sol
+++ b/src/AlchemistV3Position.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.26;
 
 import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Base64} from "@openzeppelin/contracts/utils/Base64.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {IAlchemistV3Position} from "./interfaces/IAlchemistV3Position.sol";
 import {IAlchemistV3} from "./interfaces/IAlchemistV3.sol";
 
@@ -12,11 +14,18 @@ import {IAlchemistV3} from "./interfaces/IAlchemistV3.sol";
  *         is allowed to mint and burn tokens. Minting returns a unique token id.
  */
 contract AlchemistV3Position is ERC721Enumerable {
+    using Strings for uint256;
+
     /// @notice The only address allowed to mint and burn position tokens.
     address public alchemist;
 
     /// @notice Counter used for generating unique token ids.
     uint256 private _currentTokenId;
+
+    // SVG colors
+    string private constant SVG_BG_COLOR = "#d4c3b7";
+    string private constant SVG_TEXT_COLOR = "#0a3a60";
+    string private constant SVG_ACCENT_COLOR = "#0a3a60";
 
     /// @notice An error which is used to indicate that the functioin call failed becasue the caller is not the alchemist
     error CallerNotAlchemist();
@@ -65,6 +74,62 @@ contract AlchemistV3Position is ERC721Enumerable {
 
     function burn(uint256 tokenId) public onlyAlchemist {
         _burn(tokenId);
+    }
+
+    /**
+     * @notice Generate on-chain SVG for token
+     * @param tokenId The token ID
+     * @return SVG string
+     */
+    function generateSVG(uint256 tokenId) internal pure returns (string memory) {
+        return string(
+            abi.encodePacked(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 484" width="300" height="484">',
+                '<rect width="300" height="484" fill="',
+                SVG_BG_COLOR,
+                '" />',
+                '<circle cx="150" cy="150" r="120" fill="none" stroke="',
+                SVG_ACCENT_COLOR,
+                '" stroke-width="4" />',
+                '<text x="150" y="120" font-family="Arial" font-size="24" fill="',
+                SVG_TEXT_COLOR,
+                '" text-anchor="middle">Alchemist V3</text>',
+                '<text x="150" y="150" font-family="Arial" font-size="28" fill="',
+                SVG_ACCENT_COLOR,
+                '" text-anchor="middle" font-weight="bold">Position</text>',
+                '<text x="150" y="190" font-family="monospace" font-size="24" fill="',
+                SVG_TEXT_COLOR,
+                '" text-anchor="middle">#',
+                tokenId.toString(),
+                "</text>",
+                "</svg>"
+            )
+        );
+    }
+
+    /**
+     * @notice Returns the token URI with embedded SVG
+     * @param tokenId The token ID
+     * @return Full token URI with data
+     */
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        // revert if the token does not exist
+        ERC721(address(this)).ownerOf(tokenId);
+
+        string memory svg = generateSVG(tokenId);
+        string memory json = Base64.encode(
+            abi.encodePacked(
+                '{"name": "AlchemistV3 Position #',
+                tokenId.toString(),
+                '", ',
+                '"description": "Position token for Alchemist V3", ',
+                '"image": "data:image/svg+xml;base64,',
+                Base64.encode(bytes(svg)),
+                '"}'
+            )
+        );
+
+        return string(abi.encodePacked("data:application/json;base64,", json));
     }
 
     /**

--- a/src/test/libraries/AlchemistNFTHelper.sol
+++ b/src/test/libraries/AlchemistNFTHelper.sol
@@ -1,4 +1,5 @@
-import "../../interfaces/IAlchemistV3Position.sol";
+import {IAlchemistV3Position} from "../../interfaces/IAlchemistV3Position.sol";
+import {CustomBase64} from "./CustomBase64.sol";
 
 library AlchemistNFTHelper {
     /**
@@ -15,7 +16,7 @@ library AlchemistNFTHelper {
         if (tokenCount == 0) {
             return tokenIds;
         }
-        
+
         // Loop through each token and retrieve its token ID via the enumerable interface.
         for (uint256 i = 0; i < tokenCount; i++) {
             tokenIds[i] = IAlchemistV3Position(nft).tokenOfOwnerByIndex(owner, i);
@@ -31,10 +32,58 @@ library AlchemistNFTHelper {
     function getFirstTokenId(address owner, address nft) public view returns (uint256 tokenId) {
         uint256[] memory tokenIds = getAllTokenIdsForOwner(owner, nft);
 
-        if (tokenIds.length == 0) { 
+        if (tokenIds.length == 0) {
             return 0;
         }
 
         tokenId = tokenIds[0];
+    }
+
+    /**
+     * @notice Slices a string
+     * @param text The string to slice
+     * @param start The start index
+     * @param length The length of the slice
+     * @return result The sliced string
+     */
+    function slice(string memory text, uint256 start, uint256 length) internal pure returns (string memory) {
+        bytes memory textBytes = bytes(text);
+        bytes memory result = new bytes(length);
+        for (uint256 i = 0; i < length; i++) {
+            result[i] = textBytes[start + i];
+        }
+        return string(result);
+    }
+
+    function contains(string memory source, string memory keyword) internal pure returns (bool) {
+        bytes memory sourceBytes = bytes(source);
+        bytes memory keywordBytes = bytes(keyword);
+
+        if (keywordBytes.length > sourceBytes.length) {
+            return false;
+        }
+
+        for (uint256 i = 0; i <= sourceBytes.length - keywordBytes.length; i++) {
+            bool found = true;
+            for (uint256 j = 0; j < keywordBytes.length; j++) {
+                if (sourceBytes[i + j] != keywordBytes[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function base64Content(string memory uri) internal pure returns (string memory) {
+        return slice(uri, 29, bytes(uri).length - 29);
+    }
+
+    function jsonContent(string memory uri) internal pure returns (string memory) {
+        return string(CustomBase64.decode(base64Content(uri)));
     }
 }

--- a/src/test/libraries/CustomBase64.sol
+++ b/src/test/libraries/CustomBase64.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+library CustomBase64 {
+    string internal constant TABLE_ENCODE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    function encode(bytes memory data) internal pure returns (string memory) {
+        if (data.length == 0) return "";
+
+        // Output length: 4 bytes for each 3 bytes (rounded up)
+        uint256 outputLength = 4 * ((data.length + 2) / 3);
+        bytes memory output = new bytes(outputLength);
+
+        uint256 j = 0;
+        for (uint256 i = 0; i < data.length; i += 3) {
+            // Load 3 bytes or whatever is left
+            uint24 input = 0;
+            if (i < data.length) input |= uint24(uint8(data[i])) << 16;
+            if (i + 1 < data.length) input |= uint24(uint8(data[i + 1])) << 8;
+            if (i + 2 < data.length) input |= uint24(uint8(data[i + 2]));
+
+            // Convert to 4 base64 characters
+            for (uint256 k = 0; k < 4; k++) {
+                uint8 index = uint8((input >> (18 - 6 * k)) & 0x3F);
+                output[j++] = bytes(TABLE_ENCODE)[index];
+            }
+        }
+
+        // Replace characters with '=' for padding
+        if (data.length % 3 == 1) {
+            output[outputLength - 2] = bytes1("=");
+            output[outputLength - 1] = bytes1("=");
+        } else if (data.length % 3 == 2) {
+            output[outputLength - 1] = bytes1("=");
+        }
+
+        return string(output);
+    }
+
+    function decode(string memory input) internal pure returns (bytes memory) {
+        bytes memory data = bytes(input);
+        require(data.length % 4 == 0, "Invalid base64 string length");
+
+        uint256 paddingLength = 0;
+        if (data.length > 0) {
+            if (data[data.length - 1] == "=") paddingLength++;
+            if (data.length > 1 && data[data.length - 2] == "=") paddingLength++;
+        }
+
+        uint256 outputLength = (data.length / 4) * 3 - paddingLength;
+        bytes memory output = new bytes(outputLength);
+
+        uint256 j = 0;
+        uint24 temp = 0;
+
+        for (uint256 i = 0; i < data.length; i += 4) {
+            temp = 0;
+
+            for (uint256 k = 0; k < 4; k++) {
+                uint8 value;
+                bytes1 char = data[i + k];
+
+                if (char >= 0x41 && char <= 0x5A) {
+                    // A-Z
+                    value = uint8(char) - 0x41;
+                } else if (char >= 0x61 && char <= 0x7A) {
+                    // a-z
+                    value = uint8(char) - 0x61 + 26;
+                } else if (char >= 0x30 && char <= 0x39) {
+                    // 0-9
+                    value = uint8(char) - 0x30 + 52;
+                } else if (char == 0x2B) {
+                    // +
+                    value = 62;
+                } else if (char == 0x2F) {
+                    // /
+                    value = 63;
+                } else if (char == 0x3D) {
+                    // =
+                    value = 0; // Padding character
+                } else {
+                    revert("Invalid base64 character");
+                }
+
+                temp = (temp << 6) | value;
+            }
+
+            // Convert 24 bits to 3 bytes
+            if (j < outputLength) output[j++] = bytes1(uint8(temp >> 16));
+            if (j < outputLength) output[j++] = bytes1(uint8(temp >> 8));
+            if (j < outputLength) output[j++] = bytes1(uint8(temp));
+        }
+
+        return output;
+    }
+}


### PR DESCRIPTION
Ticket : 

7 - Missing _baseURI() override causes empty NFT metadata

This is a placeholder for on chain metadata, so the base uri doesn't just return an empty string.
Example of the SVG returned for token id 32 :  https://jsfiddle.net/na602x1k/



