### PR TITLE
Alchemist Fee Vaults, Liquidation Steps and Fees

### DIFF
--- a/src/AlchemistETHVault.sol
+++ b/src/AlchemistETHVault.sol
@@ -6,102 +6,39 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IWETH} from "./interfaces/IWETH.sol";
+import {AbstractFeeVault} from "./adapters/AbstractFeeVault.sol";
 /**
  * @title AlchemistETHVault
  * @notice A simple vault for ETH/WETH deposits that only allows withdrawals by authorized parties
  * @dev Supports both native ETH and WETH deposits
  */
 
-contract AlchemistETHVault is ReentrancyGuard {
+contract AlchemistETHVault is AbstractFeeVault, ReentrancyGuard {
     using SafeERC20 for IERC20;
-
-    // Error for unauthorized access
-    error Unauthorized(address caller);
     // Error for failed transfers
+
     error TransferFailed();
-    // Error for invalid amounts
-    error InvalidAmount();
-    // Error for invalid WETH addresses
-    error InvalidWETHAddress();
-    // Error for invalid admin addresses
-    error InvalidAdminAddress();
-
-    // Address of the WETH contract
-    address public immutable weth;
-    // Address of the admin
-    address public admin;
-    // Address of the AlchemistV3 contract
-    address public alchemist;
-
-    // Event to track deposits
-    event Deposited(address indexed depositor, uint256 amount);
-    // Event to track withdrawals
-    event Withdrawn(address indexed recipient, uint256 amount);
-    // Event to track alchemist address updates
-    event AlchemistV3Updated(address indexed newAlchemist);
 
     /**
      * @param _weth Address of the WETH contract
      * @param _alchemist Address of the AlchemistV3 contract
-     * @param _admin Address of the admin
+     * @param _owner Address of the owner
      */
-    constructor(address _weth, address _alchemist, address _admin) {
-        if (_weth == address(0)) {
-            revert  InvalidWETHAddress();
-        }
-
-        if (_admin == address(0)) {
-            revert  InvalidAdminAddress();
-        }
-
-        weth = _weth;
-        admin = _admin;
-        alchemist = _alchemist;
-    }
-
-    /**
-     * @dev Modifier to restrict access to admin
-     */
-    modifier onlyAdmin() {
-        if (msg.sender != admin) {
-            revert Unauthorized(msg.sender);
-        }
-        _;
-    }
-
-    /**
-     * @dev Modifier to restrict access to AlchemistV3 or admin
-     */
-    modifier onlyAuthorized() {
-        if (msg.sender != alchemist && msg.sender != admin) {
-            revert Unauthorized(msg.sender);
-        }
-        _;
-    }
+    constructor(address _weth, address _alchemist, address _owner) AbstractFeeVault(_weth, _alchemist, _owner) {}
 
     /**
      * @notice Get the total deposits in the vault
      * @return Total deposits
      */
-    function getTotalDeposits() public view returns (uint256) {
+    function totalDeposits() public view override returns (uint256) {
         return address(this).balance;
-    }
-
-    /**
-     * @notice Update the AlchemistV3 contract address
-     * @param _alchemist New AlchemistV3 address
-     */
-    function setAlchemist(address _alchemist) external onlyAdmin {
-        require(_alchemist != address(0), "Invalid AlchemistV3 address");
-        alchemist = _alchemist;
-        emit AlchemistV3Updated(_alchemist);
     }
 
     /**
      * @notice Deposit ETH into the vault
      */
     function deposit() external payable nonReentrant {
-        if (msg.value == 0) revert InvalidAmount();
+        if (msg.value == 0) revert ZeroAmount();
         _deposit(msg.sender, msg.value);
     }
 
@@ -115,13 +52,13 @@ contract AlchemistETHVault is ReentrancyGuard {
      * @param amount Amount of WETH to deposit
      */
     function depositWETH(uint256 amount) external nonReentrant {
-        if (amount == 0) revert InvalidAmount();
+        if (amount == 0) revert ZeroAmount();
 
         // Transfer WETH from sender to this contract
-        IERC20(weth).safeTransferFrom(msg.sender, address(this), amount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
         // Unwrap WETH to ETH
-        IWETH(weth).withdraw(amount);
+        IWETH(token).withdraw(amount);
 
         // Record the deposit
         _deposit(msg.sender, amount);
@@ -141,11 +78,11 @@ contract AlchemistETHVault is ReentrancyGuard {
      * @param recipient Address to receive the funds
      * @param amount Amount to withdraw
      */
-    function withdraw(address recipient, uint256 amount) external onlyAuthorized nonReentrant {
-        if (amount == 0) revert InvalidAmount();
+    function withdraw(address recipient, uint256 amount) external override onlyAuthorized nonReentrant {
+        if (amount == 0) revert ZeroAmount();
 
         // Check if the vault has enough balance
-        if (amount > address(this).balance) revert InvalidAmount();
+        if (amount > address(this).balance) revert InsufficientBalance();
 
         // Send as native ETH
         (bool success,) = recipient.call{value: amount}("");

--- a/src/AlchemistTokenVault.sol
+++ b/src/AlchemistTokenVault.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./base/Errors.sol";
+import "./adapters/AbstractFeeVault.sol";
+
+/**
+ * @title AlchemistTokenVault
+ * @notice A vault that holds a specific ERC20 token, allowing anyone to deposit
+ * but only authorized parties to withdraw.
+ */
+contract AlchemistTokenVault is AbstractFeeVault {
+    /**
+     * @notice Constructor initializes the token vault
+     * @param _token The ERC20 token managed by this vault
+     * @param _alchemist The Alchemist contract address that will be authorized
+     * @param _owner The owner of the vault
+     */
+    constructor(address _token, address _alchemist, address _owner) AbstractFeeVault(_token, _alchemist, _owner) {}
+
+    /**
+     * @notice Allows anyone to deposit tokens into the vault
+     * @param amount The amount of tokens to deposit
+     */
+    function deposit(uint256 amount) external {
+        _checkNonZeroAmount(amount);
+        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        emit Deposited(msg.sender, amount);
+    }
+
+    /**
+     * @notice Allows only authorized accounts to withdraw tokens
+     * @param recipient The address to receive the tokens
+     * @param amount The amount of tokens to withdraw
+     */
+    function withdraw(address recipient, uint256 amount) external override onlyAuthorized {
+        _checkNonZeroAddress(recipient);
+        _checkNonZeroAmount(amount);
+
+        IERC20(token).transfer(recipient, amount);
+        emit Withdrawn(recipient, amount);
+    }
+
+    /**
+     * @notice Get the total deposits in the vault
+     * @return Total deposits
+     */
+    function totalDeposits() public view override returns (uint256) {
+        return IERC20(token).balanceOf(address(this));
+    }
+}

--- a/src/AlchemistV3.sol
+++ b/src/AlchemistV3.sol
@@ -724,8 +724,6 @@ contract AlchemistV3 is IAlchemistV3, Initializable {
 
         // Transfer the repaid tokens from the account to the transmuter.
         TokenUtils.safeTransfer(yieldToken, address(this), creditToYield);
-        // emit Repay(sender, amount, recipientTokenId, creditToYield);
-
         return creditToYield;
     }
 

--- a/src/AlchemistV3.sol
+++ b/src/AlchemistV3.sol
@@ -464,7 +464,7 @@ contract AlchemistV3 is IAlchemistV3, Initializable {
     }
 
     /// @inheritdoc IAlchemistV3Actions
-    function repay(uint256 amount, uint256 recipientTokenId) public returns (uint256) {
+    function repay(uint256 amount, uint256 recipientTokenId) external returns (uint256) {
         _checkArgument(amount > 0);
         _checkForValidAccountId(recipientTokenId);
         Account storage account = _accounts[recipientTokenId];

--- a/src/adapters/AbstractFeeVault.sol
+++ b/src/adapters/AbstractFeeVault.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import {IFeeVault} from "../interfaces/IFeeVault.sol";
+
+/**
+ * @title AbstractVault
+ * @notice Abstract base class for Alchemist vaults that handles authorization logic
+ * @dev Extend this to implement ETH or ERC20 token vaults
+ */
+abstract contract AbstractFeeVault is IFeeVault, Ownable {
+    address public immutable token;
+    // Custom errors
+
+    error Unauthorized();
+    error ZeroAddress();
+    error ZeroAmount();
+    error InsufficientBalance();
+
+    // Mapping of addresses authorized to withdraw
+    mapping(address => bool) public authorized;
+
+    // Events
+    event Deposited(address indexed from, uint256 amount);
+    event Withdrawn(address indexed to, uint256 amount);
+    event AuthorizationUpdated(address indexed account, bool status);
+
+    /**
+     * @dev Modifier to restrict access to authorized accounts
+     */
+    modifier onlyAuthorized() {
+        if (!authorized[msg.sender]) revert Unauthorized();
+        _;
+    }
+
+    /**
+     * @notice Constructor to initialize the vault
+     * @param _token The ERC20 token managed by this vault
+     * @param _alchemist The Alchemist contract address
+     * @param _owner The vault owner address
+     */
+    constructor(address _token, address _alchemist, address _owner) Ownable(_owner) {
+        _checkNonZeroAddress(_token);
+        _checkNonZeroAddress(_alchemist);
+        token = _token;
+        authorized[_alchemist] = true;
+        authorized[_owner] = true;
+        emit AuthorizationUpdated(_alchemist, true);
+    }
+
+    /**
+     * @notice Sets the authorization status of an account
+     * @param account The address to authorize/deauthorize
+     * @param status True to authorize, false to deauthorize
+     */
+    function setAuthorization(address account, bool status) external onlyOwner {
+        _checkNonZeroAddress(account);
+        authorized[account] = status;
+        emit AuthorizationUpdated(account, status);
+    }
+
+    /**
+     * @notice Validates that an address is not the zero address
+     * @param account The address to validate
+     */
+    function _checkNonZeroAddress(address account) internal pure {
+        if (account == address(0)) revert ZeroAddress();
+    }
+
+    /**
+     * @notice Validates that an amount is greater than zero
+     * @param amount The amount to validate
+     */
+    function _checkNonZeroAmount(uint256 amount) internal pure {
+        if (amount == 0) revert ZeroAmount();
+    }
+
+    /**
+     * @notice Abstract function to withdraw assets from the vault
+     * @param recipient Address to receive the assets
+     * @param amount Amount to withdraw
+     */
+    function withdraw(address recipient, uint256 amount) external virtual override;
+
+    /**
+     * @notice Abstract function to get total deposits in the vault
+     * @return Total deposits in the vault
+     */
+    function totalDeposits() external view virtual override returns (uint256);
+}

--- a/src/base/Errors.sol
+++ b/src/base/Errors.sol
@@ -18,3 +18,9 @@ error InsufficientAllowance();
 
 /// @notice An error used to indicate that the function input data is missing
 error MissingInputData();
+
+/// @notice An error used to indicate that the function input data is missing
+error ZeroAmount();
+
+/// @notice An error used to indicate that the function input data is missing
+error ZeroAddress();

--- a/src/interfaces/IAlchemistETHVault.sol
+++ b/src/interfaces/IAlchemistETHVault.sol
@@ -8,6 +8,12 @@ pragma solidity 0.8.26;
  */
 interface IAlchemistETHVault {
     /**
+     * @notice Get the ERC20 token managed by this vault
+     * @return The WETH token address
+     */
+    function token() external view returns (address);
+
+    /**
      * @notice Deposit WETH into the vault
      * @param amount Amount of WETH to deposit
      */

--- a/src/interfaces/IAlchemistTokenVault.sol
+++ b/src/interfaces/IAlchemistTokenVault.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title IAlchemistTokenVault
+ * @notice Interface for the AlchemistTokenVault contract
+ */
+interface IAlchemistTokenVault {
+    /**
+     * @notice Get the ERC20 token managed by this vault
+     * @return The ERC20 token address
+     */
+    function token() external view returns (address);
+
+    /**
+     * @notice Get the address of the Alchemist contract
+     * @return The Alchemist contract address
+     */
+    function alchemist() external view returns (address);
+
+    /**
+     * @notice Check if an address is authorized to withdraw
+     * @param withdrawer The address to check
+     * @return Whether the address is authorized
+     */
+    function authorizedWithdrawers(address withdrawer) external view returns (bool);
+
+    /**
+     * @notice Allows anyone to deposit tokens into the vault
+     * @param amount The amount of tokens to deposit
+     */
+    function deposit(uint256 amount) external;
+
+    /**
+     * @notice Allows only the Alchemist or authorized withdrawers to withdraw tokens
+     * @param to The address to receive the tokens
+     * @param amount The amount of tokens to withdraw
+     */
+    function withdraw(address to, uint256 amount) external;
+
+    /**
+     * @notice Sets the authorized status of a withdrawer
+     * @param withdrawer The address to authorize/deauthorize
+     * @param status True to authorize, false to deauthorize
+     */
+    function setAuthorizedWithdrawer(address withdrawer, bool status) external;
+
+    /**
+     * @notice Updates the Alchemist address
+     * @param _alchemist The new Alchemist address
+     */
+    function setAlchemist(address _alchemist) external;
+
+    /**
+     * @notice Emitted when tokens are deposited
+     */
+    event Deposited(address indexed from, uint256 amount);
+
+    /**
+     * @notice Emitted when tokens are withdrawn
+     */
+    event Withdrawn(address indexed to, uint256 amount);
+
+    /**
+     * @notice Emitted when an authorized withdrawer status changes
+     */
+    event AuthorizedWithdrawerSet(address indexed withdrawer, bool status);
+
+    /**
+     * @notice Emitted when the Alchemist address is updated
+     */
+    event AlchemistUpdated(address indexed newAlchemist);
+}

--- a/src/interfaces/IFeeVault.sol
+++ b/src/interfaces/IFeeVault.sol
@@ -1,0 +1,24 @@
+pragma solidity >=0.5.0;
+
+/// @title  IFeeVault
+/// @author Alchemix Finance
+interface IFeeVault {
+    /**
+     * @notice Get the ERC20 token managed by this vault
+     * @return The ERC20 token address
+     */
+    function token() external view returns (address);
+
+    /**
+     * @notice Get the total deposits in the vault
+     * @return Total deposits
+     */
+    function totalDeposits() external view returns (uint256);
+
+    /**
+     * @notice Withdraw funds from the vault to a target address
+     * @param recipient Address to receive the funds
+     * @param amount Amount to withdraw
+     */
+    function withdraw(address recipient, uint256 amount) external;
+}

--- a/src/test/AlchemistETHVault.t.sol
+++ b/src/test/AlchemistETHVault.t.sol
@@ -26,176 +26,54 @@ import {Unauthorized, IllegalArgument, IllegalState, MissingInputData} from "../
 import {AlchemistNFTHelper} from "./libraries/AlchemistNFTHelper.sol";
 import {IAlchemistV3Position} from "../interfaces/IAlchemistV3Position.sol";
 import {AlchemistETHVault} from "../AlchemistETHVault.sol";
-import {ETHUSDPriceFeedAdapter} from "../adapters/ETHUSDPriceFeedAdapter.sol";
-
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IWETH} from "../interfaces/IWETH.sol";
 
 import {VmSafe} from "../../lib/forge-std/src/Vm.sol";
 import {TokenUtils} from "../libraries/TokenUtils.sol";
+import {AbstractFeeVault} from "../adapters/AbstractFeeVault.sol";
 
 contract AlchemistETHVaultTest is Test {
-    // ----- [SETUP] Variables for setting up a minimal CDP -----
+    AlchemistETHVault public ethVault;
+    address public owner = address(1);
+    address public alchemist = address(2);
+    address public user = address(3);
+    address public otherUser = address(4);
+    address public weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2); // mainnent weth example
 
-    // Callable contract variables
-    AlchemistV3 alchemist;
-    Transmuter transmuter;
-    AlchemistV3Position alchemistNFT;
-    AlchemistETHVault ethVault;
-
-    // // Proxy variables
-    TransparentUpgradeableProxy proxyAlchemist;
-    TransparentUpgradeableProxy proxyTransmuter;
-
-    // // Contract variables
-    // CheatCodes cheats = CheatCodes(HEVM_ADDRESS);
-    AlchemistV3 alchemistLogic;
-    Transmuter transmuterLogic;
-    AlchemicTokenV3 alToken;
-    Whitelist whitelist;
-
-    // Token addresses
-    TestERC20 fakeUnderlyingToken;
-    TestYieldToken fakeYieldToken;
-    ETHUSDPriceFeedAdapter ethUsdAdapter;
-    // WETH address
-    address public weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-    address ETH_USD_PRICE_FEED_MAINNET = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
-    uint256 ETH_USD_UPDATE_TIME_MAINNET = 3600 seconds;
-
-    // Total minted debt
-    uint256 public minted;
-
-    // Total debt burned
-    uint256 public burned;
-
-    // Total tokens sent to transmuter
-    uint256 public sentToTransmuter;
-
-    // Parameters for AlchemicTokenV2
-    string public _name;
-    string public _symbol;
-    uint256 public _flashFee;
-    address public alOwner;
-
-    mapping(address => bool) users;
-
-    uint256 public minimumCollateralization = uint256(1e18 * 1e18) / 9e17;
-
-    // ----- Variables for deposits & withdrawals -----
-
-    // random EOA for testing
-    address externalUser = address(0x69E8cE9bFc01AA33cD2d02Ed91c72224481Fa420);
-
-    // another random EOA for testing
-    address anotherExternalUser = address(0x420Ab24368E5bA8b727E9B8aB967073Ff9316969);
-
-    // another random EOA for testing
-    address yetAnotherExternalUser = address(0x520aB24368e5Ba8B727E9b8aB967073Ff9316961);
-
-    // another random EOA for testing
-    address someWhale = address(0x521aB24368E5Ba8b727e9b8AB967073fF9316961);
+    uint256 public constant AMOUNT = 100 * 10 ** 18;
 
     function setUp() external {
-        // test maniplulation for convenience
-        address caller = address(0xdead);
-        address proxyOwner = address(this);
-        vm.assume(caller != address(0));
-        vm.assume(proxyOwner != address(0));
-        vm.assume(caller != proxyOwner);
-        vm.startPrank(caller);
-
-        // Fake tokens
-
-        fakeUnderlyingToken = new TestERC20(100e18, uint8(18));
-        fakeYieldToken = new TestYieldToken(address(fakeUnderlyingToken));
-        ethUsdAdapter =
-            new ETHUSDPriceFeedAdapter(ETH_USD_PRICE_FEED_MAINNET, ETH_USD_UPDATE_TIME_MAINNET, TokenUtils.expectDecimals(address(fakeUnderlyingToken)));
-
-        alToken = new AlchemicTokenV3(_name, _symbol, _flashFee);
-
-        ITransmuter.TransmuterInitializationParams memory transParams = ITransmuter.TransmuterInitializationParams({
-            syntheticToken: address(alToken),
-            feeReceiver: address(this),
-            timeToTransmute: 5_256_000,
-            transmutationFee: 10,
-            exitFee: 20,
-            graphSize: 52_560_000
-        });
-
-        // Contracts and logic contracts
-        alOwner = caller;
-        transmuterLogic = new Transmuter(transParams);
-        alchemistLogic = new AlchemistV3();
-        whitelist = new Whitelist();
-
-        // AlchemistV3 proxy
-        AlchemistInitializationParams memory params = AlchemistInitializationParams({
-            admin: alOwner,
-            debtToken: address(alToken),
-            underlyingToken: address(fakeUnderlyingToken),
-            yieldToken: address(fakeYieldToken),
-            blocksPerYear: 2_600_000,
-            depositCap: type(uint256).max,
-            minimumCollateralization: minimumCollateralization,
-            collateralizationLowerBound: 1_052_631_578_950_000_000, // 1.05 collateralization
-            globalMinimumCollateralization: 1_111_111_111_111_111_111, // 1.1
-            tokenAdapter: address(fakeYieldToken),
-            ethUsdAdapter: address(ethUsdAdapter),
-            transmuter: address(transmuterLogic),
-            protocolFee: 0,
-            protocolFeeReceiver: address(10),
-            liquidatorFee: 300 // in bps? 3%
-        });
-
-        bytes memory alchemParams = abi.encodeWithSelector(AlchemistV3.initialize.selector, params);
-        proxyAlchemist = new TransparentUpgradeableProxy(address(alchemistLogic), proxyOwner, alchemParams);
-        alchemist = AlchemistV3(address(proxyAlchemist));
-
         // Deploy vault
-        ethVault = new AlchemistETHVault(address(weth), address(alchemist), alOwner);
-
-        // Whitelist alchemist proxy for minting tokens
-        alToken.setWhitelist(address(proxyAlchemist), true);
-
-        whitelist.add(address(0xbeef));
-        whitelist.add(externalUser);
-        whitelist.add(anotherExternalUser);
-
-        transmuterLogic.setAlchemist(address(alchemist));
-        transmuterLogic.setDepositCap(uint256(type(int256).max));
-
-        alchemistNFT = new AlchemistV3Position(address(alchemist));
-        alchemist.setAlchemistPositionNFT(address(alchemistNFT));
-
-        vm.stopPrank();
+        vm.prank(owner);
+        ethVault = new AlchemistETHVault(address(weth), alchemist, owner);
     }
 
     // === CONSTRUCTOR TESTS ===
     function testConstructor() public view {
-        assertEq(ethVault.weth(), address(weth));
-        assertEq(ethVault.alchemist(), address(alchemist));
+        assertEq(ethVault.token(), weth);
+        assertEq(ethVault.authorized(address(alchemist)), true);
     }
 
     function testConstructorZeroAddressReverts() public {
-        vm.expectRevert("Invalid WETH address");
-        new AlchemistETHVault(address(0), address(alchemist), alOwner);
+        vm.expectRevert(AbstractFeeVault.ZeroAddress.selector);
+        new AlchemistETHVault(address(0), address(alchemist), owner);
     }
 
     function testDeposit() public {
         uint256 amount = 1 ether;
         uint256 startingAmount = 10 ether;
         // Give some ETH to the external user
-        vm.deal(externalUser, startingAmount);
-        uint256 initialBalance = address(externalUser).balance;
-        vm.startPrank(externalUser);
+        vm.deal(user, startingAmount);
+        uint256 initialBalance = address(user).balance;
+        vm.startPrank(user);
 
         // Deposit ETH
         ethVault.deposit{value: amount}();
 
         // Verify the user's ETH balance decreased
-        assertEq(address(externalUser).balance, initialBalance - amount);
-        assertEq(address(ethVault).balance, amount);
+        assertEq(address(user).balance, initialBalance - amount);
+        assertEq(ethVault.totalDeposits(), amount);
         vm.stopPrank();
     }
 
@@ -203,31 +81,33 @@ contract AlchemistETHVaultTest is Test {
         uint256 amount = 1 ether;
         uint256 startingAmount = 10 ether;
         // Give some ETH to the external user
-        vm.deal(externalUser, startingAmount);
-        uint256 initialBalance = address(externalUser).balance;
+        vm.deal(user, startingAmount);
+        uint256 initialBalance = address(user).balance;
+        vm.startPrank(user);
 
-        vm.startPrank(externalUser);
-
-        // Deposit ETH
-        address(ethVault).call{value: amount};
+        // Deposit ETH to ethVault instead of back to self
+        (bool success,) = address(ethVault).call{value: amount}("");
+        assertTrue(success, "ETH transfer failed");
 
         // Verify the user's ETH balance decreased
-        assertEq(address(externalUser).balance, initialBalance - amount);
-        assertEq(address(ethVault).balance, amount);
+        assertEq(address(user).balance, initialBalance - amount);
+        // Verify the vault received the ETH
+        assertEq(ethVault.totalDeposits(), amount);
 
         vm.stopPrank();
     }
 
     function testWithdrawETH() public {
         uint256 amount = 2 ether;
-        uint256 initialBalance = address(externalUser).balance;
+        uint256 initialBalance = address(user).balance;
 
-        vm.startPrank(anotherExternalUser);
+        vm.startPrank(otherUser);
 
         // Give some ETH to the external user
-        vm.deal(anotherExternalUser, 10 ether);
+        vm.deal(otherUser, 10 ether);
         // Deposit ETH
-        address(ethVault).call{value: amount};
+        (bool success,) = address(ethVault).call{value: amount}("");
+        assertTrue(success, "ETH transfer failed");
 
         vm.stopPrank();
 
@@ -235,15 +115,15 @@ contract AlchemistETHVaultTest is Test {
         vm.deal(address(ethVault), amount);
 
         // Verify the user's ETH balance decreased
-        assertEq(address(ethVault).balance, amount);
+        assertEq(ethVault.totalDeposits(), amount);
 
         vm.startPrank(address(alchemist));
 
         // Withdraw ETH
-        ethVault.withdraw(externalUser, amount / 2);
+        ethVault.withdraw(user, amount / 2);
 
         // Verify the user's ETH balance increased
-        assertEq(address(externalUser).balance, initialBalance + amount / 2);
+        assertEq(address(user).balance, initialBalance + amount / 2);
 
         vm.stopPrank();
     }
@@ -253,11 +133,11 @@ contract AlchemistETHVaultTest is Test {
         // Set up the vault with some ETH
         vm.deal(address(ethVault), withdrawAmount);
 
-        vm.startPrank(externalUser);
+        vm.startPrank(user);
 
         vm.expectRevert();
         // Withdraw ETH
-        ethVault.withdraw(externalUser, withdrawAmount);
+        ethVault.withdraw(user, withdrawAmount);
 
         vm.stopPrank();
     }
@@ -267,20 +147,20 @@ contract AlchemistETHVaultTest is Test {
         address newAlchemist = address(0x123);
 
         // Non-owner tries to call an owner-only function
-        vm.startPrank(externalUser);
+        vm.startPrank(user);
         vm.expectRevert();
-        ethVault.setAlchemist(newAlchemist);
+        ethVault.setAuthorization(newAlchemist, true);
         vm.stopPrank();
 
         // Owner calls the same function
-        vm.startPrank(alOwner);
-        ethVault.setAlchemist(newAlchemist);
-        assertEq(ethVault.alchemist(), newAlchemist);
+        vm.startPrank(owner);
+        ethVault.setAuthorization(newAlchemist, true);
+        assertEq(ethVault.authorized(newAlchemist), true);
         vm.stopPrank();
     }
 
     function testDepositETHWithZeroAmountReverts() public {
-        vm.startPrank(externalUser);
+        vm.startPrank(user);
         vm.expectRevert();
         ethVault.depositWETH(0);
         vm.stopPrank();
@@ -294,30 +174,30 @@ contract AlchemistETHVaultTest is Test {
 
         // Mock a callback from the alchemist (e.g., after withdrawing WETH)
         // First, ensure the vault has no ETH
-        assertEq(address(ethVault).balance, 0);
+        assertEq(ethVault.totalDeposits(), 0);
 
         // Send ETH to the vault as if it's a callback
         (bool success,) = address(ethVault).call{value: amount}("");
-        assertTrue(success);
+        assertTrue(success, "ETH transfer failed");
 
         // Verify the vault received the ETH
-        assertEq(address(ethVault).balance, amount);
+        assertEq(ethVault.totalDeposits(), amount);
     }
 
     function testDepositWETH() public {
         uint256 amount = 1 ether;
         uint256 startingAmount = 10 ether;
         // Give some ETH to the external user
-        vm.deal(externalUser, startingAmount);
-        uint256 initialBalance = address(externalUser).balance;
+        vm.deal(user, startingAmount);
+        uint256 initialBalance = address(user).balance;
 
-        vm.startPrank(externalUser);
+        vm.startPrank(user);
         IWETH(weth).deposit{value: amount}();
         IERC20(weth).approve(address(ethVault), amount);
 
         // Expect the correct event with the right parameters
         vm.expectEmit(true, true, true, true);
-        emit AlchemistETHVault.Deposited(externalUser, amount);
+        emit AbstractFeeVault.Deposited(user, amount);
 
         // Start recording logs to count events
         vm.recordLogs();
@@ -336,8 +216,8 @@ contract AlchemistETHVaultTest is Test {
             }
         }
 
-        assertEq(address(externalUser).balance, initialBalance - amount);
-        assertEq(address(ethVault).balance, amount);
+        assertEq(address(user).balance, initialBalance - amount);
+        assertEq(ethVault.totalDeposits(), amount);
 
         // Verify only one event was emitted
         assertEq(eventCount, 1, "Deposited event should be emitted exactly once");

--- a/src/test/AlchemistTokenVault.t.sol
+++ b/src/test/AlchemistTokenVault.t.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import "forge-std/Test.sol";
+import "../AlchemistTokenVault.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../base/Errors.sol";
+
+// Simple ERC20 token for testing
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock Token", "MOCK") {
+        _mint(msg.sender, 1_000_000 * 10 ** 18);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract AlchemistTokenVaultTest is Test {
+    AlchemistTokenVault public vault;
+    MockToken public token;
+
+    address public owner = address(1);
+    address public alchemist = address(2);
+    address public user = address(3);
+    address public withdrawer = address(4);
+    address public unauthorizedUser = address(5);
+
+    uint256 public constant AMOUNT = 100 * 10 ** 18;
+
+    function setUp() public {
+        // Deploy token and mint to user
+        token = new MockToken();
+        token.mint(user, AMOUNT * 2);
+
+        // Deploy vault
+        vm.prank(owner);
+        vault = new AlchemistTokenVault(address(token), alchemist, owner);
+
+        // Setup authorized withdrawer
+        vm.prank(owner);
+        vault.setAuthorization(withdrawer, true);
+
+        // Approve vault to spend user's tokens
+        vm.prank(user);
+        token.approve(address(vault), AMOUNT * 2);
+    }
+
+    function testDeposit() public {
+        uint256 initialBalance = token.balanceOf(address(vault));
+
+        // User deposits tokens
+        vm.prank(user);
+        vault.deposit(AMOUNT);
+
+        // Check balances
+        assertEq(token.balanceOf(address(vault)), initialBalance + AMOUNT, "Vault balance should increase");
+        assertEq(token.balanceOf(user), AMOUNT, "User balance should decrease");
+    }
+
+    function testWithdrawByAlchemist() public {
+        // First deposit tokens
+        vm.prank(user);
+        vault.deposit(AMOUNT);
+
+        address recipient = address(10);
+        uint256 initialVaultBalance = token.balanceOf(address(vault));
+        uint256 initialRecipientBalance = token.balanceOf(recipient);
+
+        // Alchemist withdraws tokens
+        vm.prank(alchemist);
+        vault.withdraw(recipient, AMOUNT / 2);
+
+        // Check balances
+        assertEq(token.balanceOf(address(vault)), initialVaultBalance - AMOUNT / 2, "Vault balance should decrease");
+        assertEq(token.balanceOf(recipient), initialRecipientBalance + AMOUNT / 2, "Recipient balance should increase");
+    }
+
+    function testWithdrawByAuthorizedWithdrawer() public {
+        // First deposit tokens
+        vm.prank(user);
+        vault.deposit(AMOUNT);
+
+        address recipient = address(11);
+        uint256 initialVaultBalance = token.balanceOf(address(vault));
+        uint256 initialRecipientBalance = token.balanceOf(recipient);
+
+        // Authorized withdrawer withdraws tokens
+        vm.prank(withdrawer);
+        vault.withdraw(recipient, AMOUNT / 2);
+
+        // Check balances
+        assertEq(token.balanceOf(address(vault)), initialVaultBalance - AMOUNT / 2, "Vault balance should decrease");
+        assertEq(token.balanceOf(recipient), initialRecipientBalance + AMOUNT / 2, "Recipient balance should increase");
+    }
+
+    function testUnauthorizedWithdrawReverts() public {
+        // First deposit tokens
+        vm.prank(user);
+        vault.deposit(AMOUNT);
+
+        // Unauthorized user attempts to withdraw
+        vm.prank(unauthorizedUser);
+        vm.expectRevert(Unauthorized.selector);
+        vault.withdraw(unauthorizedUser, AMOUNT);
+    }
+
+    function testOwnerCanAddNewAlchemist() public {
+        // First deposit tokens
+        vm.prank(user);
+        vault.deposit(AMOUNT);
+
+        // New alchemist address
+        address newAlchemist = address(12);
+        vm.prank(owner);
+
+        // Owner adds new alchemist
+        vault.setAuthorization(newAlchemist, true);
+
+        vm.prank(newAlchemist);
+        vault.withdraw(address(13), AMOUNT / 2); // Should succeed
+
+        assertEq(token.balanceOf(address(13)), AMOUNT / 2, "Recipient should receive tokens");
+    }
+
+    function testRevokeAuthorizedAccount() public {
+        // First deposit tokens
+        vm.prank(user);
+        vault.deposit(AMOUNT);
+
+        // New alchemist address
+        address newAlchemist = address(12);
+        vm.prank(owner);
+
+        // Owner adds new alchemist
+        vault.setAuthorization(newAlchemist, true);
+
+        vm.prank(newAlchemist);
+        vault.withdraw(newAlchemist, AMOUNT / 2); // Should succeed
+
+        vm.prank(owner);
+
+        // Owner adds new alchemist
+        vault.setAuthorization(newAlchemist, false);
+
+        vm.prank(newAlchemist);
+        vm.expectRevert(Unauthorized.selector);
+        vault.withdraw(newAlchemist, AMOUNT / 2); // Should now revert
+    }
+
+    function testZeroAmountDepositReverts() public {
+        vm.prank(user);
+        vm.expectRevert();
+        vault.deposit(0);
+    }
+
+    function testZeroAmountWithdrawReverts() public {
+        vm.prank(alchemist);
+        vm.expectRevert(ZeroAmount.selector);
+        vault.withdraw(address(10), 0);
+    }
+
+    function testWithdrawToZeroAddressReverts() public {
+        vm.prank(alchemist);
+        vm.expectRevert(ZeroAddress.selector);
+        vault.withdraw(address(0), AMOUNT);
+    }
+}

--- a/src/test/IntegrationTest.t.sol
+++ b/src/test/IntegrationTest.t.sol
@@ -23,7 +23,6 @@ import {InsufficientAllowance} from "../base/Errors.sol";
 import {Unauthorized, IllegalArgument, IllegalState, MissingInputData} from "../base/Errors.sol";
 import {AlchemistNFTHelper} from "./libraries/AlchemistNFTHelper.sol";
 import {AlchemistV3Position} from "../AlchemistV3Position.sol";
-import {ETHUSDPriceFeedAdapter} from "../adapters/ETHUSDPriceFeedAdapter.sol";
 import {AlchemistETHVault} from "../AlchemistETHVault.sol";
 import {TokenUtils} from "../libraries/TokenUtils.sol";
 
@@ -44,7 +43,6 @@ contract RedemptionIntegrationTest is Test {
     Transmuter transmuterLogic;
     AlchemicTokenV3 alToken;
     Whitelist whitelist;
-    ETHUSDPriceFeedAdapter ethUsdAdapter;
 
     // Total minted debt
     uint256 public minted;
@@ -129,7 +127,6 @@ contract RedemptionIntegrationTest is Test {
         transmuterLogic = new Transmuter(transParams);
         alchemistLogic = new AlchemistV3();
         whitelist = new Whitelist();
-        ethUsdAdapter = new ETHUSDPriceFeedAdapter(ETH_USD_PRICE_FEED_MAINNET, ETH_USD_UPDATE_TIME_MAINNET, TokenUtils.expectDecimals(address(USDC)));
 
         // // Proxy contracts
         // // TransmuterBuffer proxy
@@ -159,7 +156,6 @@ contract RedemptionIntegrationTest is Test {
             collateralizationLowerBound: 1_052_631_578_950_000_000, // 1.05 collateralization
             globalMinimumCollateralization: 1_111_111_111_111_111_111, // 1.1
             tokenAdapter: address(vaultAdapter),
-            ethUsdAdapter: address(ethUsdAdapter),
             transmuter: address(transmuterLogic),
             protocolFee: 100,
             protocolFeeReceiver: receiver,

--- a/src/test/InvariantsTest.t.sol
+++ b/src/test/InvariantsTest.t.sol
@@ -23,7 +23,6 @@ import {Unauthorized, IllegalArgument, IllegalState, MissingInputData} from "../
 import {AlchemistNFTHelper} from "./libraries/AlchemistNFTHelper.sol";
 import {AlchemistV3Position} from "../AlchemistV3Position.sol";
 import {AlchemistETHVault} from "../AlchemistETHVault.sol";
-import {ETHUSDPriceFeedAdapter} from "../adapters/ETHUSDPriceFeedAdapter.sol";
 import {TokenUtils} from "../libraries/TokenUtils.sol";
 
 contract InvariantsTest is Test {
@@ -34,7 +33,6 @@ contract InvariantsTest is Test {
     Transmuter transmuter;
     AlchemistV3Position alchemistNFT;
     AlchemistETHVault ethVault;
-    ETHUSDPriceFeedAdapter ethUsdAdapter;
 
     // // Proxy variables
     TransparentUpgradeableProxy proxyAlchemist;
@@ -116,9 +114,6 @@ contract InvariantsTest is Test {
 
         fakeUnderlyingToken = new TestERC20(100e18, uint8(18));
         fakeYieldToken = new TestYieldToken(address(fakeUnderlyingToken));
-        ethUsdAdapter =
-            new ETHUSDPriceFeedAdapter(ETH_USD_PRICE_FEED_MAINNET, ETH_USD_UPDATE_TIME_MAINNET, TokenUtils.expectDecimals(address(fakeUnderlyingToken)));
-
         alToken = new AlchemicTokenV3(_name, _symbol, _flashFee);
 
         ITransmuter.TransmuterInitializationParams memory transParams = ITransmuter.TransmuterInitializationParams({
@@ -162,7 +157,6 @@ contract InvariantsTest is Test {
             collateralizationLowerBound: 1_052_631_578_950_000_000, // 1.05 collateralization
             globalMinimumCollateralization: 1_111_111_111_111_111_111, // 1.1
             tokenAdapter: address(fakeYieldToken),
-            ethUsdAdapter: address(ethUsdAdapter),
             transmuter: address(transmuterLogic),
             protocolFee: 0,
             protocolFeeReceiver: address(10),


### PR DESCRIPTION
- Added vaults which will store the underlying token of an alchemist, to be used primarily to help fund liquidator fees.
- Updated liquidation steps, to include rapayment functionality to handle earmarked debt before liquidation checks.
- Updated fee calculations.

# Vaults

Main updates : 
- A regular ERC20 token vault [AlchemistTokenVault](https://github.com/alchemix-finance/v3-poc/blob/94c1fa7c12ec25545ba7169cbc1734396d2b2f9c/src/AlchemistTokenVault.sol)
- An ETH/WETH vault that should be used for ETH/WETH underlying token alchemists [AlchemistETHVault.sol](https://github.com/alchemix-finance/v3-poc/blob/94c1fa7c12ec25545ba7169cbc1734396d2b2f9c/src/AlchemistETHVault.sol)
- Multiple alchemists may pull from the same vault if they all use the same underlying token 
- If a liquidator fee cannot be satisfied from account collateral (remaining collateral of the account being liquidated)
the remaining fee will be withdrawn from the vault (if available) and sent to the liquidator. (See [here](https://github.com/alchemix-finance/v3-poc/blob/94c1fa7c12ec25545ba7169cbc1734396d2b2f9c/src/AlchemistV3.sol#L707-L713)) 

E.g. 
- Alchemist A manages yield token A, which has the USDC underlying token
- Alchemist B manages yield token B, which has the USDC underlying token
- Both may pull from a vault that is set up to store USDC

Removed usage of the ETHUSD adapter
- Will no longer convert between pairs that require a price feed


# Liquidation Steps and Fees

Main updates : 

- force repayment if undercollaterlaized, then recheck collarateral ratio [_forceRepay](https://github.com/alchemix-finance/v3-poc/blob/5438dc2e3810faa89f05e9a5b45eb70ed50065f4/src/AlchemistV3.sol#L699)
- calc fees
---

## 1. Liquidation Calculation

- **Notation**  
  - `c` = current collateral value  
  - `d` = current debt value  
  - `m` = minimum post‑liquidation collateralization = 100 / 90 ≈ 1.1111 (i.e. 111.11%)  
  - trigger when LTV ≥ 95% ⇒ `c/d ≤ 1/0.95 ≈ 1.05263`

- **Compute net liquidation amount**  
  Solve for `A` (collateral & debt removed) so post‑liquidation ratio is exactly `m`:
  ```math
  \frac{c - A}{d - A} = m
  \quad\Longrightarrow\quad
  A = \frac{m \cdot d - c}{m - 1}
  ```

- **Effects**  
  - Burn `A` of debt from the user’s position.  
  - Seize `A` of collateral into the protocol.  
  - Remaining vault sits exactly at 111.11% collateralization.

---

## 2. Protocol Fee (Surplus‑Based, i.e. account collateral - debt)

- **Surplus definition**  
  ```math
  S = c - d  \quad(\text{always ≥ 0 at trigger})
  ```

- **Fee rate**  
  - Parameter `p` ∈ [0, 1], e.g. 0.10 = 10% of surplus.

- **Compute fee**  
  ```math
  \mathrm{fee} = p \times S
  ```

- **Execution steps**  
  1. **Pull** `fee` from the surplus:  
     ```solidity
     uint256 fee = (c - d) * p;
     uint256 c1 = c - fee;
     ...
     TokenUtils.safeTransfer(yieldToken, msg.sender, feeInYield);
     ```
  2. **Compute** `A` on the **reduced** collateral `c1`:
     ```math
     A = \frac{m \cdot d - c1}{m - 1}
     ```
  3. **Burn** `A` debt and **seize** `A` collateral for the protocol.

- **Key property**  
  - The protocol always receives the full `A` it needs to cover the erased debt.  
  - The liquidator’s reward is drawn **only** from over‑collateralization.

---

## 3. Bonus Fee (Fixed % of Debt Burned)

To further reward liquidators, we pull a **bonus** from an external vault:

- **Bonus rate**  
  - Basis‑points `bps` on `debtToBurn`, e.g. 100 bps = 1%.

- **Compute bonus**  
  ```solidity
       ...
  uint256 feeBonus = debtToBurn * bps / 10_000;
       ...
  IFeeVault(alchemistFeeVault).withdraw(msg.sender, feeBonus);
  ```

- **Combined flow**  
  ```solidity
  // 1) protocol fee (surplus-based)
  uint256 fee        = (c - d) * p;
  uint256 c1         = c - fee;
  // 2) net liquidation
  uint256 A          = (m*d - c1) / (m - 1);
  // 3) bonus
  uint256 bonus      = A * bps / 10_000;
  // 4) execute transfers
TokenUtils.safeTransfer(yieldToken, msg.sender, feeInYield);
...
TokenUtils.safeTransfer(yieldToken, transmuter, adjustedDebtToBurn);
....
IFeeVault(alchemistFeeVault).withdraw(msg.sender, feeInUnderlying);
  ```
  - **Protocol** nets `A` collateral, burns `A` debt.  
  - **Liquidator** gets `fee + bonus`.

---

## 4. Example Parameters

| Parameter               | Value                    |
|-------------------------|--------------------------|
| Initial collateral `c`  | 1 000                    |
| Initial debt `d`        |   900                    |
| Min. collateralization  | 100 / 90 ≈ 1.1111         |
| Trigger LTV             | 95% (ratio ≤ 1.05263)    |
| Protocol fee `p`        | 3% of surplus           |
| Bonus rate `bps`        | 3% of `debtToBurn`       |

---

